### PR TITLE
release-drafterとWPバージョン監視ワークフローを追加

### DIFF
--- a/.github/.release-drafter.yml
+++ b/.github/.release-drafter.yml
@@ -1,0 +1,18 @@
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wp-outdated.yml
+++ b/.github/workflows/wp-outdated.yml
@@ -1,0 +1,40 @@
+name: Latest WP Support
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 5 * *" # Every month on the 5th at 2am UTC
+
+jobs:
+  is-outdated:
+    name: Check if WP version is outdated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+
+      - name: Install Node
+        uses: actions/setup-node@master
+        with:
+          node-version: '18'
+
+      - name: Check wp version
+        uses: tarosky/farmhand-wp-action@v1
+        id: wp_version
+
+      - name: Update Issue if needed
+        if: ${{ 'true' == steps.wp_version.outputs.should_update }}
+        uses: actions-ecosystem/action-create-issue@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          title: WordPress ${{ steps.wp_version.outputs.version }} をサポートする
+          body: |
+            ## TODO
+
+            - [ ] プラグインがWordPress ${{ steps.wp_version.outputs.version }} に対応しているかチェックする
+            - [ ] README.MD の "Tested up to" を更新する
+
+          labels: |
+            wp-org
+          assignees: |
+            fumikito


### PR DESCRIPTION
## Summary
- **release-drafter**: masterへのマージ時にドラフトリリースを自動更新（PRタイトルがChangelogに反映される）
- **release-drafter設定**: Features / Bug Fixes / Maintenance のカテゴリ分類
- **wp-outdated**: 毎月5日にTested up toバージョンをチェック、古ければIssueを自動作成

## Test plan
- [ ] masterにマージ後、Releases画面にドラフトが作成されること
- [ ] Actionsタブからwp-outdatedを手動実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)